### PR TITLE
Add GetYoutubeResume method and API endpoint

### DIFF
--- a/src/RecettesFamille/Managers/AiGenerators/AiManager.cs
+++ b/src/RecettesFamille/Managers/AiGenerators/AiManager.cs
@@ -92,6 +92,34 @@ public class AiManager(IServiceProvider serviceProvider, IConfiguration config, 
         return GptMapper.ConvertToRecipeDto(serialized);
     }
 
+
+    public async Task<string> GetYoutubeResume(string transcript, CancellationToken cancellationToken = default)
+    {
+
+        IChatClient client = serviceProvider.GetRequiredKeyedService<IChatClient>("OpenAi");
+
+        var ask = $@"Fait moi un résumé de ce transcript, sous forme de point claire et façile à lire :
+
+        === Début du transcript ===
+        {transcript}
+        === Fin du transcript ===";
+
+        var messages = new ChatMessage[]
+        {
+            new (ChatRole.User, ask)
+        };
+
+        ChatResponse completion = await client.GetResponseAsync(messages, new ChatOptions() { ResponseFormat = ChatResponseFormatJson.Text }, cancellationToken: cancellationToken);
+
+        var resultText = completion.Message.Text;
+
+        ArgumentNullException.ThrowIfNullOrEmpty(resultText);
+
+        await ReportChatConsumption(completion, AiClientType.OpenAi);
+        return resultText;
+    }
+
+
     /// <summary>
     /// Reports the consumption of image generation to the AI repository.
     /// </summary>

--- a/src/RecettesFamille/Managers/AiGenerators/IAiManager.cs
+++ b/src/RecettesFamille/Managers/AiGenerators/IAiManager.cs
@@ -7,5 +7,8 @@ namespace RecettesFamille.Managers.AiGenerators
     {
         Task<RecipeDto> ConvertRecipe(string recipe, AiClientType aiClientTypeEnum, CancellationToken cancellationToken = default);
         Task<string> AskImage(string recipeName, CancellationToken cancellationToken = default);
+
+
+        Task<string> GetYoutubeResume(string transcript, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
Implemented GetYoutubeResume in AiManager to summarize YouTube transcripts using IChatClient. 

Updated IAiManager interface to include the new method. Modified Program.cs to register AiManager for dependency injection and added a minimal API endpoint at /api/youtube-summary to handle transcript requests.