### PR TITLE
Improve semantic search filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ RecettesFamille est une application web pour gérer et partager des recettes de 
 - Confirmation par email
 - Gestion des ingrédients et des instructions de recette
 - Génération d'images de recettes avec OpenAI
+- Recherche sémantique filtrable par nom, tag ou ingrédient
 
 ## Structure du projet
 


### PR DESCRIPTION
## Summary
- update `SemanticSearch` to support filtering by tags and ingredients
- document new filtering capability in README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eed6e18348328ad38ca1a312d0e1d