### PR TITLE
Expose recipe id in semantic search

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ RecettesFamille est une application web pour gérer et partager des recettes de 
 - Confirmation par email
 - Gestion des ingrédients et des instructions de recette
 - Génération d'images de recettes avec OpenAI
+- Recherche sémantique filtrable par nom, tag ou ingrédient
+- Les résultats de recherche incluent maintenant l'identifiant de la recette
 
 ## Structure du projet
 

--- a/src/RecettesFamille.Ai/Services/Ingestion/SQLRecipeSource.cs
+++ b/src/RecettesFamille.Ai/Services/Ingestion/SQLRecipeSource.cs
@@ -68,6 +68,7 @@ public class SQLRecipeSource(ApplicationDbContext dbContext) : IIngestionSource
         return paragraphs.Zip(embeddings).Select((pair, index) => new SemanticSearchRecord
         {
             Key = $"{recipe.Id}_{index}",
+            RecipeId = recipe.Id,
             RecipeName = recipe.Name, // Updated property
             Text = pair.First,
             Tags = recipe.Tags,

--- a/src/RecettesFamille.Ai/Services/SemanticSearch.cs
+++ b/src/RecettesFamille.Ai/Services/SemanticSearch.cs
@@ -5,7 +5,13 @@ namespace RecettesFamille.Ai.Services;
 
 public class SemanticSearch(IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator, IVectorStore vectorStore)
 {
-    public async Task<IReadOnlyList<SemanticSearchRecord>> SearchAsync(string text, string? recipeNameFilter, int maxResults)
+    public async Task<IReadOnlyList<SemanticSearchRecord>> SearchAsync(
+        string text,
+        int? recipeIdFilter = null,
+        string? recipeNameFilter = null,
+        string? tagFilter = null,
+        string? ingredientFilter = null,
+        int maxResults = 5)
     {
         var queryEmbedding = await embeddingGenerator.GenerateVectorAsync(text);
         var vectorCollection = vectorStore.GetCollection<string, SemanticSearchRecord>("data-chatapp2-ingested");
@@ -13,8 +19,13 @@ public class SemanticSearch(IEmbeddingGenerator<string, Embedding<float>> embedd
         var nearest = await vectorCollection.VectorizedSearchAsync(queryEmbedding, new VectorSearchOptions<SemanticSearchRecord>
         {
             Top = maxResults,
-            Filter = recipeNameFilter is { Length: > 0 } ? record => record.RecipeName == recipeNameFilter : null,
+            Filter = record =>
+                (!recipeIdFilter.HasValue || record.RecipeId == recipeIdFilter) &&
+                (string.IsNullOrEmpty(recipeNameFilter) || record.RecipeName == recipeNameFilter) &&
+                (string.IsNullOrEmpty(tagFilter) || (record.Tags ?? string.Empty).Contains(tagFilter)) &&
+                (string.IsNullOrEmpty(ingredientFilter) || (record.Ingredients ?? string.Empty).Contains(ingredientFilter)),
         });
+
         var results = new List<SemanticSearchRecord>();
         await foreach (var item in nearest.Results)
         {

--- a/src/RecettesFamille.Ai/Services/SemanticSearchRecord.cs
+++ b/src/RecettesFamille.Ai/Services/SemanticSearchRecord.cs
@@ -9,6 +9,9 @@ public class SemanticSearchRecord
     public required string Key { get; set; }
 
     [VectorStoreRecordData(IsFilterable = true)]
+    public int RecipeId { get; set; }
+
+    [VectorStoreRecordData(IsFilterable = true)]
     public required string RecipeName { get; set; } // Updated from FileName to RecipeName
 
     [VectorStoreRecordData]
@@ -40,6 +43,7 @@ public class SemanticSearchRecord
         var sb = new StringBuilder();
 
         sb.AppendLine($"Key: {Key}");
+        sb.AppendLine($"RecipeId: {RecipeId}");
         sb.AppendLine($"RecipeName: {RecipeName}");
         sb.AppendLine($"Text: {Text}");
         sb.AppendLine($"Tags: {Tags ?? "N/A"}");

--- a/src/RecettesFamille/Components/AiChat/ChatTest.razor
+++ b/src/RecettesFamille/Components/AiChat/ChatTest.razor
@@ -146,7 +146,7 @@ Example of reply:
         [Description("If possible, specify the filename to search that file only. If not provided or empty, the search includes all files.")] string? filenameFilter = null)
     {
         await InvokeAsync(StateHasChanged);
-        var results = await Search.SearchAsync(searchPhrase, filenameFilter, maxResults: 25);
+        var results = await Search.SearchAsync(searchPhrase, recipeNameFilter: filenameFilter, maxResults: 25);
         return results.Select(result => result.ToString());
     }
 


### PR DESCRIPTION
## Summary
- include `RecipeId` field in `SemanticSearchRecord`
- populate `RecipeId` when ingesting recipes
- support searching by recipe id
- update Blazor component call and README

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eed6e18348328ad38ca1a312d0e1d